### PR TITLE
[PKG-1997] upgrade to 73.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 channels:
   icu73: icu73
+
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  icu73: icu73

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -36,6 +36,7 @@ fi
             --disable-extras      \
             --disable-layout      \
             --disable-tests       \
+            --enable-static       \
             ${EXTRA_OPTS}
 
 make -j${CPU_COUNT} ${VERBOSE_CM}

--- a/recipe/icu-22356.patch
+++ b/recipe/icu-22356.patch
@@ -1,0 +1,117 @@
+From 4fd9d6ce9a951e66e727b296138f22cd05479de1 Mon Sep 17 00:00:00 2001
+From: Fredrik Roubert <roubert@google.com>
+Date: Tue, 18 Apr 2023 23:39:28 +0200
+Subject: [PATCH] ICU-22356 Use ConstChar16Ptr to safely cast from UChar* to
+ char16_t*.
+
+This is necessary for this header file to be usable by clients that
+define UCHAR_TYPE as a type not compatible with char16_t, eg. uint16_t.
+---
+ icu4c/source/common/unicode/ures.h                   | 9 +++++----
+ icu4c/source/test/intltest/Makefile.in               | 2 +-
+ icu4c/source/test/intltest/intltest.vcxproj          | 1 +
+ icu4c/source/test/intltest/intltest.vcxproj.filters  | 3 +++
+ icu4c/source/test/intltest/uchar_type_build_test.cpp | 7 +++++++
+ 5 files changed, 17 insertions(+), 5 deletions(-)
+ create mode 100644 icu4c/source/test/intltest/uchar_type_build_test.cpp
+
+diff --git a/icu4c/source/common/unicode/ures.h b/icu4c/source/common/unicode/ures.h
+index cc25b6e49cd..babc01d426a 100644
+--- a/icu4c/source/common/unicode/ures.h
++++ b/icu4c/source/common/unicode/ures.h
+@@ -25,6 +25,7 @@
+ #ifndef URES_H
+ #define URES_H
+ 
++#include "unicode/char16ptr.h"
+ #include "unicode/utypes.h"
+ #include "unicode/uloc.h"
+ 
+@@ -812,7 +813,7 @@ inline UnicodeString
+ ures_getUnicodeString(const UResourceBundle *resB, UErrorCode* status) {
+     UnicodeString result;
+     int32_t len = 0;
+-    const char16_t *r = ures_getString(resB, &len, status);
++    const char16_t *r = ConstChar16Ptr(ures_getString(resB, &len, status));
+     if(U_SUCCESS(*status)) {
+         result.setTo(true, r, len);
+     } else {
+@@ -837,7 +838,7 @@ inline UnicodeString
+ ures_getNextUnicodeString(UResourceBundle *resB, const char ** key, UErrorCode* status) {
+     UnicodeString result;
+     int32_t len = 0;
+-    const char16_t* r = ures_getNextString(resB, &len, key, status);
++    const char16_t* r = ConstChar16Ptr(ures_getNextString(resB, &len, key, status));
+     if(U_SUCCESS(*status)) {
+         result.setTo(true, r, len);
+     } else {
+@@ -859,7 +860,7 @@ inline UnicodeString
+ ures_getUnicodeStringByIndex(const UResourceBundle *resB, int32_t indexS, UErrorCode* status) {
+     UnicodeString result;
+     int32_t len = 0;
+-    const char16_t* r = ures_getStringByIndex(resB, indexS, &len, status);
++    const char16_t* r = ConstChar16Ptr(ures_getStringByIndex(resB, indexS, &len, status));
+     if(U_SUCCESS(*status)) {
+         result.setTo(true, r, len);
+     } else {
+@@ -882,7 +883,7 @@ inline UnicodeString
+ ures_getUnicodeStringByKey(const UResourceBundle *resB, const char* key, UErrorCode* status) {
+     UnicodeString result;
+     int32_t len = 0;
+-    const char16_t* r = ures_getStringByKey(resB, key, &len, status);
++    const char16_t* r = ConstChar16Ptr(ures_getStringByKey(resB, key, &len, status));
+     if(U_SUCCESS(*status)) {
+         result.setTo(true, r, len);
+     } else {
+diff --git a/icu4c/source/test/intltest/Makefile.in b/icu4c/source/test/intltest/Makefile.in
+index 8007d3c1880..f57f8d995f4 100644
+--- a/icu4c/source/test/intltest/Makefile.in
++++ b/icu4c/source/test/intltest/Makefile.in
+@@ -70,7 +70,7 @@ numbertest_parse.o numbertest_doubleconversion.o numbertest_skeletons.o \
+ static_unisets_test.o numfmtdatadriventest.o numbertest_range.o erarulestest.o \
+ formattedvaluetest.o formatted_string_builder_test.o numbertest_permutation.o \
+ units_data_test.o units_router_test.o units_test.o displayoptions_test.o \
+-numbertest_simple.o
++numbertest_simple.o uchar_type_build_test.o
+ 
+ DEPS = $(OBJECTS:.o=.d)
+ 
+diff --git a/icu4c/source/test/intltest/intltest.vcxproj b/icu4c/source/test/intltest/intltest.vcxproj
+index 0985ba1e808..71ce1254038 100644
+--- a/icu4c/source/test/intltest/intltest.vcxproj
++++ b/icu4c/source/test/intltest/intltest.vcxproj
+@@ -291,6 +291,7 @@
+     <ClCompile Include="units_data_test.cpp" />
+     <ClCompile Include="units_router_test.cpp" />
+     <ClCompile Include="units_test.cpp" />
++    <ClCompile Include="uchar_type_build_test.cpp" />
+   </ItemGroup>
+   <ItemGroup>
+     <ClInclude Include="colldata.h" />
+diff --git a/icu4c/source/test/intltest/intltest.vcxproj.filters b/icu4c/source/test/intltest/intltest.vcxproj.filters
+index ffe9bc1467d..5d8777c5aaf 100644
+--- a/icu4c/source/test/intltest/intltest.vcxproj.filters
++++ b/icu4c/source/test/intltest/intltest.vcxproj.filters
+@@ -568,6 +568,9 @@
+     <ClCompile Include="units_test.cpp">
+       <Filter>formatting</Filter>
+     </ClCompile>
++    <ClCompile Include="uchar_type_build_test.cpp">
++      <Filter>configuration</Filter>
++    </ClCompile>
+   </ItemGroup>
+   <ItemGroup>
+     <ClInclude Include="itrbbi.h">
+diff --git a/icu4c/source/test/intltest/uchar_type_build_test.cpp b/icu4c/source/test/intltest/uchar_type_build_test.cpp
+new file mode 100644
+index 00000000000..ca9335441a3
+--- /dev/null
++++ b/icu4c/source/test/intltest/uchar_type_build_test.cpp
+@@ -0,0 +1,7 @@
++// © 2023 and later: Unicode, Inc. and others.
++// License & terms of use: http://www.unicode.org/copyright.html#License
++
++// ICU-22356 Test that client code can be built with UCHAR_TYPE redefined.
++#undef UCHAR_TYPE
++#define UCHAR_TYPE uint16_t
++#include "unicode/ures.h"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "68.1" %}
+{% set version = "73.1" %}
 {% set version_under = version.replace(".", "_") %}
 {% set version_hyphen = version.replace(".", "-") %}
 
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://github.com/unicode-org/icu/releases/download/release-{{ version_hyphen }}/icu4c-{{ version_under }}-src.tgz
-    sha256: a9f2e3d8b4434b8e53878b4308bd1e6ee51c9c7042e2b1a376abefb6fbb29f2d
+    sha256: a457431de164b4aa7eca00ed134d00dfbf88a77c6986a10ae7774fc076bb8c45
     patches:
       # Include an extra header when using mingw.
       - icu4c-4_9_1-mingw-w64-mkdir-compatibility.patch  # [win]
@@ -17,7 +17,7 @@ source:
       - mach-port-t.patch  # [osx]
 
   - url: https://github.com/unicode-org/icu/releases/download/release-{{ version_hyphen }}/icu4c-{{ version_under }}-data.zip
-    sha256: 03ea8b4694155620548c8c0ba20444f1e7db246cc79e3b9c4fc7a960b160d510
+    sha256: 07d7557efb30fc2e9b74652f1525603b3209a4539d2d345d704e3df3bf9b957e
     folder: source/data
 
 build:
@@ -76,8 +76,9 @@ test:
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
-  home: http://site.icu-project.org/
+  home: https://icu.unicode.org/
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: 'International Components for Unicode.'
   description: |
@@ -85,8 +86,8 @@ about:
     Unicode and Globalization support for software applications. ICU is
     widely portable and gives applications the same results on all platforms
     and between C/C++ and Java software.
-  doc_url: http://site.icu-project.org/design
-  dev_url: http://source.icu-project.org/repos/icu/
+  doc_url: https://unicode-org.github.io/icu/
+  dev_url: https://github.com/unicode-org/icu
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,8 +76,9 @@ test:
     - icuinfo --help
     - icu-config --help  # [not win]
     - makeconv gb-18030-2000.ucm
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - genrb de.txt  # [not win]
+    - echo "de.res" > list.txt  # [not win]
+    - pkgdata -p mybundle list.txt  # [not win]
 
 about:
   home: https://icu.unicode.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ source:
       # Omit lib prefix on libraries.
       - icu-config.patch  # [win]
       - mach-port-t.patch  # [osx]
+      # patch for ICU-22356, required by qt
+      - icu-22356.patch
 
   - url: https://github.com/unicode-org/icu/releases/download/release-{{ version_hyphen }}/icu4c-{{ version_under }}-data.zip
     sha256: 07d7557efb30fc2e9b74652f1525603b3209a4539d2d345d704e3df3bf9b957e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ build:
     # icu changes their file extension with each major rev.  Default pin OK.
     - {{ pin_subpackage('icu') }}
   skip: True  # [win and vc>14]
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-genrb de.txt
-echo "de.res" > list.txt
-pkgdata -p mybundle list.txt


### PR DESCRIPTION
Additional patches may be required as long as I rebuild/upgrade more reverse dependencies.

Tests were not running completely, due to the existence of `run_tests.sh`. I fixed that too.

This won't be merged until the whole dependency chain is done.