### PR TITLE
Replace strip_prefix with prefix in anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -2,7 +2,7 @@ anaconda_config_version: 1
 upstream_sources:
   - github:
       identifier: unicode-org/icu
-      strip_prefix: cldr%2F
+      prefix: cldr%2F
       strip_suffix: -rc
       use_max_tag: true
       from_pattern: ^release-(.+)$


### PR DESCRIPTION
## Summary
- Replace legacy `strip_prefix` with `prefix` in `anaconda.yaml`.

## Verification
- Config-only key rename; no recipe changes.

Made with [Cursor](https://cursor.com)